### PR TITLE
Fix homepage_url typo in manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,7 @@
   "name": "View on Sci-Hub ",
   "description": "View paper on sci-hub. It will append the current url to sci-hub.",
   "author": "Yana Agun Siswanto",
-  "homepage-url": "http://github.com/bekicot/scihub-firefox",
+  "homepage_url": "http://github.com/bekicot/scihub-firefox",
 
   "permissions": [
     "activeTab",


### PR DESCRIPTION
Hello @bekicot 

Right now, when debugging the extension in Firefox this warning get raised:

> Reading manifest: Warning processing homepage-url: An unexpected property was found in the WebExtension manifest.

This PR fix it. 

For reference: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url